### PR TITLE
Allow using shallow clones as source

### DIFF
--- a/bin/incremental-git-filterbranch
+++ b/bin/incremental-git-filterbranch
@@ -604,7 +604,7 @@ prepareWorkerRepository () {
 #   $1: the name of the branch to work with
 processBranch () {
 	echo '  - fetching'
-	git -C "${WORKER_REPOSITORY_DIR}" fetch --quiet --tags source "${1}"
+	git -C "${WORKER_REPOSITORY_DIR}" fetch --update-shallow --quiet --tags source "${1}"
 	echo '  - setting current branch'
 	git -C "${WORKER_REPOSITORY_DIR}" update-ref "refs/heads/filter-branch/source/${1}" "refs/remotes/source/${1}"
 	git -C "${WORKER_REPOSITORY_DIR}" symbolic-ref HEAD "refs/heads/filter-branch/source/${1}"


### PR DESCRIPTION
Sample output demonstrating a problem that this change fixes (while filtering a shallow repository):

```
+ echo '  - fetching'
  - fetching
+ git -C /path/to/temp/worker-13c43a54c95e3f3437439950948004a2 fetch --quiet -
-tags source mybranch
error: Could not read 698e7ab4fee66cdc158f3f89b7d5853a641d7f57
fatal: Failed to traverse parents of commit 8d5dc10f94b714e90e8516c840298de4eed7a366
error: /path/to/temp/source-4e0ccd572832548afab7d6685895556b did not send all 
necessary objects

```